### PR TITLE
Don't link against libpython on non-Windows targets.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,9 +2,16 @@ project('pybind11', 'cpp', default_options : ['cpp_std=c++11'], license : 'BSD-s
 
 py3_dep = dependency('python3')
 
+# https://github.com/mesonbuild/meson/issues/4117
+if host_machine.system() == 'windows'
+	python_ext_dep = py3_dep
+else
+	python_ext_dep = py3_dep.partial_dependency(compile_args: true)
+endif
+
 pybind11_incdir = include_directories('include')
 
 pybind11_dep = declare_dependency(
 	include_directories : pybind11_incdir,
-	dependencies : py3_dep
+	dependencies : python_ext_dep
 )


### PR DESCRIPTION
CPython extension modules that are explicitly linked against `libpython` will cause undefined behavior when being used by a statically linked python interpreter such as anaconda. For this reason, the pybind11 docs [recommend not linking against libpython](https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually), saying

> On Linux and macOS, it’s better to (intentionally) not link against libpython. The symbols will be resolved when the extension library is loaded into a Python binary. This is preferable because you might have several different installations of a given Python version (e.g. the system-provided Python, and one that ships with a piece of commercial software). In this way, the plugin will work with both versions, instead of possibly importing a second Python library into a process that already contains one (which will lead to a segfault).

For similar reasons Python 3.8 is moving to [never linking against libpython on unix](https://bugs.python.org/issue34814#msg341047). 

Currently, this wrap uses `pkg-config`s output, which will often include link flags for `libpython`. For example, on homebrew:

```
$ pkg-config python3 --libs
-L/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib -lpython3.7m
```

Looking at the way other meson projects handle this situation, it seems they solve it by excluding the `pkg-config` linker flags. See for example [this pygobject patch](https://gitlab.gnome.org/GNOME/pygobject/commit/b33d1a42726a1415cc8af703df1eacda09abee48) and [this pycairo patch](https://github.com/pygobject/pycairo/pull/120/files). This MR applies a patch similar to the above `pycairo` patch to not link against `libpython` explicitly unless on windows.