### PR TITLE
Add 2.6.0 version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,10 @@
+project('pybind11', 'cpp', default_options : ['cpp_std=c++14'], license : 'BSD-style', version : '2.6.0')
+
+py3_dep = dependency('python3')
+
+pybind11_incdir = include_directories('include')
+
+pybind11_dep = declare_dependency(
+	include_directories : pybind11_incdir,
+	dependencies : py3_dep
+)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = pybind11-2.6.0
+source_url = https://github.com/pybind/pybind11/archive/v2.6.0.zip
+source_filename = pybind11-2.6.0.zip
+source_hash = c2ed3fc84db08f40a36ce1d03331624ed6977497b35dfed36a1423396928559a
+
+[provide]
+pybind11 = pybind11_dep


### PR DESCRIPTION
Note that I've removed fix from 2.3 since issue is closed:
https://github.com/mesonbuild/pybind11/blob/2.3.0/meson.build#L5