### PR TITLE
Add wrap files for pybind11 2.6.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,8 @@
+project('pybind11', 'cpp',
+        version : '2.6.1',
+        license : 'BSD-3-Clause')
+
+pybind11_incdir = include_directories('include')
+
+pybind11_dep = declare_dependency(
+  include_directories : pybind11_incdir)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = pybind11-2.6.1
+source_url = https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
+source_filename = pybind11-2.6.1.tar.gz
+source_hash = cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a
+
+[provide]
+pybind11 = pybind11_dep


### PR DESCRIPTION
This removed the transitive dependency to Python, as discussed in #7 and fixes the license reported in `meson.build`.